### PR TITLE
Make gcc less noisy on Cygwin and MinGW. (shadowsocks-libev)

### DIFF
--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -137,7 +137,7 @@
  * it's internal to the current library.
  */
 
-#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES
+#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES && !defined(__CYGWIN__) && !defined(__MINGW32__)
 #define CORK_EXPORT  __attribute__((visibility("default")))
 #define CORK_IMPORT  __attribute__((visibility("default")))
 #define CORK_LOCAL   __attribute__((visibility("hidden")))


### PR DESCRIPTION
Visibility attributes are not supported on Cygwin or MinGW and gcc prints hundreds of warnings like:

```
src/libcork/cli/commands.c: In function ‘cork_command_show_help’:
src/libcork/cli/commands.c:103:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
 }
 ^
```