### PR TITLE
Make gcc less noisy on Cygwin and MinGW. (simple-obfs)

### DIFF
--- a/include/libcork/config/linux.h
+++ b/include/libcork/config/linux.h
@@ -15,7 +15,11 @@
  * Endianness
  */
 
+#if defined(__FreeBSD_kernel__)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #if __BYTE_ORDER == __BIG_ENDIAN
 #define CORK_CONFIG_IS_BIG_ENDIAN      1

--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -137,7 +137,7 @@
  * it's internal to the current library.
  */
 
-#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES
+#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES && !defined(__CYGWIN__) && !defined(__MINGW32__)
 #define CORK_EXPORT  __attribute__((visibility("default")))
 #define CORK_IMPORT  __attribute__((visibility("default")))
 #define CORK_LOCAL   __attribute__((visibility("hidden")))


### PR DESCRIPTION
The same patch as #2 but for the `simple-obfs` branch.